### PR TITLE
Fix parallel build

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,15 @@ WriteMakefile(
     clean             => { FILES => "config.log config.status config.h" },
 );
 
+# by Nicholas Clark <nick@ccl4.org>
+# https://github.com/Perl/perl5/commit/4d106cc5d8fd328d39b1db3c57572dd3dec915b5
+#
+# We don't want the default subdir rule, as it creates a race condition with the
+# rule we add below.
+sub MY::subdir_x {
+    return '';
+}
+
 sub MY::postamble {
         return <<'EOF';
 


### PR DESCRIPTION
Avoid a race condition during parallel makes, which could cause the build to fail.

Fixes #3